### PR TITLE
Fix displaying Email template previews in admin dashboard for Django>2.0

### DIFF
--- a/appmail/admin.py
+++ b/appmail/admin.py
@@ -4,6 +4,7 @@ from django.contrib.postgres.fields import JSONField
 from django.core.exceptions import ValidationError
 from django.http import HttpResponseRedirect
 from django.urls import reverse
+from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
 
 from .forms import JSONWidget
@@ -137,10 +138,11 @@ class EmailTemplateAdmin(admin.ModelAdmin):
     )
 
     def _iframe(self, url):
-        return (
+        return format_html(
             "<iframe class='appmail' src='{}' onload='resizeIframe(this)'></iframe><br/>"
-            "<a href='{}' target='_blank'>View in new tab.</a>"
-            .format(url, url)
+            "<a href='{}' target='_blank'>View in new tab.</a>",
+            url,
+            url
         )
 
     # these functions are here rather than on the model so that we can get the
@@ -234,3 +236,4 @@ class EmailTemplateAdmin(admin.ModelAdmin):
 
 
 admin.site.register(EmailTemplate, EmailTemplateAdmin)
+


### PR DESCRIPTION
Django 2 requires HTML to be wrapped using `mark_safe` or `format_html`. `format_html` works similar to `str.format` method.
Before:
![image](https://user-images.githubusercontent.com/3007865/44208188-63553780-a168-11e8-845d-15140c0cd54f.png)
After:
![image](https://user-images.githubusercontent.com/3007865/44208204-6ea86300-a168-11e8-846f-3e7dd4c9e2ee.png)
