### PR TITLE
YJP-2923: Unescape special characters in email subject and plain text

### DIFF
--- a/appmail/helpers.py
+++ b/appmail/helpers.py
@@ -1,4 +1,5 @@
 import re
+from django.utils.safestring import mark_safe
 
 # regex for extracting django template {{ variable }}s
 TEMPLATE_VARS = re.compile(r'{{([ ._[a-z]*)}}')
@@ -93,7 +94,17 @@ def merge_dicts(*dicts):
     return context
 
 
-def patch_context(context, processors, request=None):
-    """Add template context_processor content to context."""
+def patch_context(context, processors, request=None, safe_string=False):
+    """
+    Add template context_processor content to context.
+    Mark context as safe when appropriate (safe=True).
+    """
     cpx = [p(request) for p in processors]
+    if safe_string:
+        context = mark_context_safe(context)
     return merge_dicts(context, *cpx)
+
+
+def mark_context_safe(context):
+    """Mark context values as safe before escaping them."""
+    return {key: mark_safe(value) for key, value in context.items()}

--- a/appmail/helpers.py
+++ b/appmail/helpers.py
@@ -94,17 +94,12 @@ def merge_dicts(*dicts):
     return context
 
 
-def patch_context(context, processors, request=None, safe_string=False):
+def patch_context(context, processors, request=None, mark_context_safe=False):
     """
     Add template context_processor content to context.
     Mark context as safe when appropriate (safe=True).
     """
     cpx = [p(request) for p in processors]
-    if safe_string:
-        context = mark_context_safe(context)
+    if mark_context_safe:
+        context = {key: mark_safe(value) for key, value in context.items()}
     return merge_dicts(context, *cpx)
-
-
-def mark_context_safe(context):
-    """Mark context values as safe before escaping them."""
-    return {key: mark_safe(value) for key, value in context.items()}

--- a/appmail/models.py
+++ b/appmail/models.py
@@ -182,7 +182,7 @@ class EmailTemplate(models.Model):
 
     def render_subject(self, context, processors=CONTEXT_PROCESSORS):
         """Render subject line."""
-        ctx = Context(helpers.patch_context(context, processors, safe_string=True))
+        ctx = Context(helpers.patch_context(context, processors, mark_context_safe=True))
         return Template(self.subject).render(ctx)
 
     def _validate_subject(self):
@@ -200,7 +200,7 @@ class EmailTemplate(models.Model):
         """Render email body in plain text or HTML format."""
         assert content_type in EmailTemplate.CONTENT_TYPES, _lazy("Invalid content type.")
         if content_type == EmailTemplate.CONTENT_TYPE_PLAIN:
-            ctx = Context(helpers.patch_context(context, processors, safe_string=True))
+            ctx = Context(helpers.patch_context(context, processors, mark_context_safe=True))
             return Template(self.body_text).render(ctx)
         if content_type == EmailTemplate.CONTENT_TYPE_HTML:
             ctx = Context(helpers.patch_context(context, processors))

--- a/appmail/models.py
+++ b/appmail/models.py
@@ -10,6 +10,7 @@ from django.template import (
     TemplateSyntaxError
 )
 from django.utils.translation import ugettext_lazy as _lazy
+from html import unescape
 
 from . import helpers
 from .settings import (
@@ -183,7 +184,7 @@ class EmailTemplate(models.Model):
     def render_subject(self, context, processors=CONTEXT_PROCESSORS):
         """Render subject line."""
         ctx = Context(helpers.patch_context(context, processors))
-        return Template(self.subject).render(ctx)
+        return unescape(Template(self.subject).render(ctx))
 
     def _validate_subject(self):
         """Try rendering the body template and capture any errors."""
@@ -201,7 +202,7 @@ class EmailTemplate(models.Model):
         assert content_type in EmailTemplate.CONTENT_TYPES, _lazy("Invalid content type.")
         ctx = Context(helpers.patch_context(context, processors))
         if content_type == EmailTemplate.CONTENT_TYPE_PLAIN:
-            return Template(self.body_text).render(ctx)
+            return unescape(Template(self.body_text).render(ctx))
         if content_type == EmailTemplate.CONTENT_TYPE_HTML:
             return Template(self.body_html).render(ctx)
 

--- a/appmail/tests/test_models.py
+++ b/appmail/tests/test_models.py
@@ -177,6 +177,23 @@ class EmailTemplateTests(TestCase):
         self.assertRaises(AssertionError, template.create_message, {}, body='foo')
         self.assertRaises(AssertionError, template.create_message, {}, alternatives='foo')
 
+    def test_create_message__special_characters(self):
+        template = EmailTemplate(
+            subject='Welcome {{ first_name }}',
+            body_text='Hello {{ first_name }}',
+            body_html='<h1>Hello {{first_name}}</h1>'
+        )
+
+        context = {'first_name': 'Test & Company'}
+        message = template.create_message(context)
+        self.assertIsInstance(message, EmailMultiAlternatives)
+        self.assertEqual(message.subject, 'Welcome Test & Company')
+        self.assertEqual(message.body, 'Hello Test & Company')
+        self.assertEqual(
+            message.alternatives,
+            [('<h1>Hello Test &amp; Company</h1>', EmailTemplate.CONTENT_TYPE_HTML)]
+        )
+
     def test_clone_template(self):
         template = EmailTemplate(
             name='Test template',


### PR DESCRIPTION
**If applied this PR will..**
  * unescape the special characters from the email subject and the plain text

**Why is this change being made?**
The mailapp works under the assumption that all the strings going into building the email template are either escaped or marked as safe. However, it is a common occurrence that templates lack the safe tag. Since we know that the email subjects and the plain text versions of the emails will not be rendered as html, we should always unescape them. 