### PR TITLE
Fix displaying special chars in email subject and body

### DIFF
--- a/appmail/helpers.py
+++ b/appmail/helpers.py
@@ -94,12 +94,8 @@ def merge_dicts(*dicts):
     return context
 
 
-def patch_context(context, processors, request=None, mark_context_safe=False):
-    """
-    Add template context_processor content to context.
-    Mark context as safe when appropriate (safe=True).
-    """
+def patch_context(context, processors, request=None):
+    """Add template context_processor content to context."""
     cpx = [p(request) for p in processors]
-    if mark_context_safe:
-        context = {key: mark_safe(value) for key, value in context.items()}
     return merge_dicts(context, *cpx)
+

--- a/appmail/models.py
+++ b/appmail/models.py
@@ -182,7 +182,7 @@ class EmailTemplate(models.Model):
 
     def render_subject(self, context, processors=CONTEXT_PROCESSORS):
         """Render subject line."""
-        ctx = Context(helpers.patch_context(context, processors, mark_context_safe=True))
+        ctx = Context(helpers.patch_context(context, processors), autoescape=False)
         return Template(self.subject).render(ctx)
 
     def _validate_subject(self):
@@ -200,7 +200,7 @@ class EmailTemplate(models.Model):
         """Render email body in plain text or HTML format."""
         assert content_type in EmailTemplate.CONTENT_TYPES, _lazy("Invalid content type.")
         if content_type == EmailTemplate.CONTENT_TYPE_PLAIN:
-            ctx = Context(helpers.patch_context(context, processors, mark_context_safe=True))
+            ctx = Context(helpers.patch_context(context, processors), autoescape=False)
             return Template(self.body_text).render(ctx)
         if content_type == EmailTemplate.CONTENT_TYPE_HTML:
             ctx = Context(helpers.patch_context(context, processors))
@@ -264,4 +264,5 @@ class EmailTemplate(models.Model):
         self.pk = None
         self.version += 1
         return self.save()
+
 

--- a/appmail/models.py
+++ b/appmail/models.py
@@ -265,4 +265,3 @@ class EmailTemplate(models.Model):
         self.version += 1
         return self.save()
 
-

--- a/appmail/tests/test_models.py
+++ b/appmail/tests/test_models.py
@@ -181,7 +181,7 @@ class EmailTemplateTests(TestCase):
         template = EmailTemplate(
             subject='Welcome {{ first_name }}',
             body_text='Hello {{ first_name }}',
-            body_html='<h1>Hello {{first_name}}</h1>'
+            body_html='<h1>Hello {{ first_name }}</h1>'
         )
 
         context = {'first_name': 'Test & Company'}
@@ -192,6 +192,31 @@ class EmailTemplateTests(TestCase):
         self.assertEqual(
             message.alternatives,
             [('<h1>Hello Test &amp; Company</h1>', EmailTemplate.CONTENT_TYPE_HTML)]
+        )
+
+    def test_create_message__special_characters__complex_context(self):
+        template = EmailTemplate(
+            subject='Hello {{ user.first_name }} and welcome to {{ company_name }}',
+            body_text='Hello {{ user.first_name }} and welcome to {{ company_name }}',
+            body_html='<h1>Hello {{ user.first_name }}</h1></br><p>Welcome to {{ company_name }}</p>'
+        )
+
+        context = {
+            'user': {
+                'first_name': 'Test & Company'
+            },
+            'company_name': 'Me & Co Inc'
+        }
+        message = template.create_message(context)
+        self.assertIsInstance(message, EmailMultiAlternatives)
+        self.assertEqual(message.subject, 'Hello Test & Company and welcome to Me & Co Inc')
+        self.assertEqual(message.body, 'Hello Test & Company and welcome to Me & Co Inc')
+        self.assertEqual(
+            message.alternatives,
+            [(
+                '<h1>Hello Test &amp; Company</h1></br><p>Welcome to Me &amp; Co Inc</p>',
+                EmailTemplate.CONTENT_TYPE_HTML
+            )]
         )
 
     def test_clone_template(self):


### PR DESCRIPTION
So the original problem was in displaying context variables with special characters.
Variables like this `Tom & Jerry` were displayed like `Tom &amp; Jerry` both in email subject and plain text:
![image](https://user-images.githubusercontent.com/3007865/46736898-d4195b80-cca2-11e8-8eca-a653a35fedb2.png)
This was because context variables were automatically escaped.
This is fixed after disabling autoescape by passing `autoescape=False` to Context.
So now it looks like this:
![image](https://user-images.githubusercontent.com/3007865/46736978-0d51cb80-cca3-11e8-9065-9d37273a0868.png)
