### PR TITLE
Misc: Ensure admin "check validity" feature works

### DIFF
--- a/appmail/admin.py
+++ b/appmail/admin.py
@@ -48,6 +48,13 @@ class ValidTemplateListFilter(admin.SimpleListFilter):
         """
         valid_ids = []
         invalid_ids = []
+
+        if not self.value():
+            # By default, the lookup is not run at all because it is
+            # computationally expensive to render the entire list of
+            # emails on every page load.
+            return
+
         for obj in queryset:
             try:
                 obj.clean()

--- a/appmail/models.py
+++ b/appmail/models.py
@@ -10,6 +10,7 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models, transaction
 from django.http import HttpRequest
 from django.template import Context, Template, TemplateDoesNotExist, TemplateSyntaxError
+from django.urls import NoReverseMatch
 from django.utils.timezone import now as tz_now
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy as _lazy
@@ -253,7 +254,7 @@ class EmailTemplate(models.Model):
             self.render_body({}, content_type=content_type)
         except TemplateDoesNotExist as ex:
             return {field_name: _("Template does not exist: {}".format(ex))}
-        except TemplateSyntaxError as ex:
+        except (TemplateSyntaxError, NoReverseMatch) as ex:
             return {field_name: str(ex)}
         else:
             return {}


### PR DESCRIPTION
1) The feature was always running, even if the list filter hadn't
   been selected, this is very unnecessary work as the feature is
   only helpful when you need it and left like this we render every
   single email on every admin list page load.

2) The valid template filter check did not handle failed URL lookups
   gracefully. It deliberately doesn't catch every possible error so
   that we only target the ones we know are related to template
   validity. It now handles this case.

3) Split the tests up to be more readable.