### PR TITLE
Misc: Django 5.2 upgrade

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -62,7 +62,7 @@ jobs:
       matrix:
         python: ["3.9", "3.10", "3.11", "3.12"]
         # build LTS versions and main
-        django: ["40", "41", "42", "50", "52", "main"]
+        django: ["42", "50", "52", "main"]
         exclude:
           - python: "3.9"
             django: "50"

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -61,19 +61,19 @@ jobs:
     strategy:
       matrix:
         python: ["3.9", "3.10", "3.11", "3.12"]
-        # build LTS version, next version, HEAD
-        django: ["32", "42", "50", "main"]
+        # build LTS versions and main
+        django: ["40", "41", "42", "50", "52", "main"]
         exclude:
           - python: "3.9"
             django: "50"
+          - python: "3.9"
+            django: "52"
           - python: "3.9"
             django: "main"
           - python: "3.10"
             django: "main"
           - python: "3.11"
-            django: "32"
-          - python: "3.12"
-            django: "32"
+            django: "main"
 
     env:
       TOXENV: django${{ matrix.django }}-py${{ matrix.python }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## v7.0.0
+
+* Add support for Django 5.2
+* Drop support for Django 3.x (including Django 3.2 LTS)
+
 ## v6.0.0
 
 * Add support for Django 5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## v7.0.0
 
 * Add support for Django 5.2
-* Drop support for Django 3.x (including Django 3.2 LTS)
+* Drop support for Django 3.x, 4.0 and 4.1
 
 ## v6.0.0
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Django app for managing transactional email templates.
 
 ## Compatibility
 
-This project requires Django 4.0+ and Python 3.9+. Django 3.x support was dropped in version 7.0. If you require compatibility with older versions of Django, please use version 6.0 or earlier.
+This project requires Django 4.2+ and Python 3.9+.
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ Django app for managing transactional email templates.
 
 ## Compatibility
 
-This project now requires Django 4.0+ and Python 3.9+. If you require a previous
-version you will have to refer to the relevant branch or tag.
+This project requires Django 4.0+ and Python 3.9+. Django 3.x support was dropped in version 7.0. If you require compatibility with older versions of Django, please use version 6.0 or earlier.
 
 ## Background
 

--- a/appmail/views.py
+++ b/appmail/views.py
@@ -1,4 +1,5 @@
 """Views supporting template previews in admin site."""
+
 from __future__ import annotations
 
 import json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,6 @@ homepage = "https://github.com/yunojuno/django-appmail"
 repository = "https://github.com/yunojuno/django-appmail"
 classifiers = [
     "Environment :: Web Environment",
-    "Framework :: Django :: 4.0",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.2",
@@ -25,7 +23,7 @@ packages = [{ include = "appmail" }]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-django = "^4.0 || ^5.0"
+django = "^4.2 || ^5.0"
 
 [tool.poetry.dev-dependencies]
 black = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-appmail"
-version = "6.0"
+version = "7.0"
 description = "Django app for managing localised email templates."
 authors = ["YunoJuno <code@yunojuno.com>"]
 license = "MIT"
@@ -9,11 +9,11 @@ homepage = "https://github.com/yunojuno/django-appmail"
 repository = "https://github.com/yunojuno/django-appmail"
 classifiers = [
     "Environment :: Web Environment",
-    "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.0",
     "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.2",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.9",
@@ -25,7 +25,7 @@ packages = [{ include = "appmail" }]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-django = "^3.2 || ^4.0 || ^5.0"
+django = "^4.0 || ^5.0"
 
 [tool.poetry.dev-dependencies]
 black = "*"
@@ -38,6 +38,9 @@ pytest-cov = "*"
 pytest-django = "*"
 ruff = "*"
 tox = "*"
+
+[tool.poetry.group.dev.dependencies]
+tox = "^4.26.0"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -4,6 +4,8 @@ from django.core.exceptions import ImproperlyConfigured
 
 DEBUG = True
 
+USE_TZ = False
+
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
@@ -56,9 +58,16 @@ TEMPLATES = [
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
-# NB - this is good for local testing only
-DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
-STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
+# Update storage settings to use the new STORAGES format
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+}
+
 STATIC_URL = "/static/"
 STATIC_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "static"))
 
@@ -67,8 +76,6 @@ SECRET_KEY = "top secret"  # noqa: S105
 ROOT_URLCONF = "tests.urls"
 
 APPEND_SLASH = True
-
-STATIC_URL = "/static/"
 
 if not DEBUG:
     raise ImproperlyConfigured("This project is only intended to be used for testing.")

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,13 @@ isolated_build = True
 envlist =
     fmt, lint, mypy,
     django-checks,
-    ; https://docs.djangoproject.com/en/5.0/releases/
-    django32-py{39,310}
+    ; Django versions: 4.0+
     django40-py{39,310}
     django41-py{39,310,311}
     django42-py{39,310,311}
     django50-py{310,311,312}
-    djangomain-py{311,312}
+    django52-py{310,311,312}
+    djangomain-py{312}
 
 [testenv]
 deps =
@@ -21,6 +21,7 @@ deps =
     django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
     django50: https://github.com/django/django/archive/stable/5.0.x.tar.gz
+    django52: https://github.com/django/django/archive/stable/5.2.x.tar.gz
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =
@@ -47,7 +48,7 @@ deps =
     ruff
 
 commands =
-    ruff appmail
+    ruff check appmail
 
 [testenv:mypy]
 description = Python source code type hints (mypy)

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,7 @@ isolated_build = True
 envlist =
     fmt, lint, mypy,
     django-checks,
-    ; Django versions: 4.0+
-    django40-py{39,310}
-    django41-py{39,310,311}
+    ; Django versions: 4.2+ (LTS)
     django42-py{39,310,311}
     django50-py{310,311,312}
     django52-py{310,311,312}
@@ -17,8 +15,6 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django40: Django>=4.0,<4.1
-    django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
     django50: https://github.com/django/django/archive/stable/5.0.x.tar.gz
     django52: https://github.com/django/django/archive/stable/5.2.x.tar.gz


### PR DESCRIPTION
Opens up Django 5.2 support by doing the following:

1. Bumping the various `tox` environment bits.
2. Removes `DEFAULT_FILE_STORAGE` and  `STATICFILES_STORAGE` from `settings.py`, which now causes the warning: `"DEFAULT_FILE_STORAGE/STORAGES are mutually exclusive."`
3. Sets `USE_TZ = False` in settings, as the default changed in 5.2.
4. Excludes `3.11` from `main` in `.github/workflows/tox.yml`, as we need to add this exclusion (Django's main branch (which will become Django 5.3/6.0) now requires Python 3.12 or newer).

**On point 2 of the above:**

The change to the storage settings does directly affect Django version compatibility in some ways worth recognising:

1. `Django 3.2 (LTS)` through 4.1: These versions primarily use the old-style settings (`DEFAULT_FILE_STORAGE` and `STATICFILES_STORAGE`). By removing these settings, we _might_ break compatibility with these older versions.
2. `Django 4.2 (LTS)`: This version supports both the old settings and the new STORAGES setting but issues deprecation warnings for the old settings. Our change addresses these warnings.
6. `Django 5.0+`: Uses the new `STORAGES` dictionary as the preferred approach, with the old settings being fully deprecated.

For full backward compatibility, we could consider using a conditional approach that supports both old and new Django versions. Something like:

```
if django.VERSION >= (4, 2):
    # Use new STORAGES setting
    STORAGES = {
        "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
        "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"},
    }
else:
    # Use old settings for compatibility
    DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
    STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
```

But - it's not clear to me that this is necessarily worth doing as it looks like 3.2 has dropped out of even extended support over a year ago:

Release Series | Latest Release | End of mainstream support1 | End of extended support
-- | -- | -- | --
3.2 LTS | 3.2.25 | December 7, 2021 | April 1, 2024
